### PR TITLE
PST-4244: Setup XCLogParser

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Josh Lesch <josh.r.lesch@gmail.com>
+Copyright (c) 2020 Hudl
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ fastlane add_plugin xclogparser
 
 [XCLogParser](https://github.com/spotify/XCLogParser) is a CLI tool that parses the SLF serialization format used by Xcode and xcodebuild to store its Build and Test logs (xcactivitylog files). This plugin provides an easy way to run XCLogParser against your builds.
 
+It is a prerequisite that `XCLogParser` is installed globally on the same machine that will be executing your Fastfile. You can find the install instruction [here](https://github.com/spotify/XCLogParser#installation) or install with `brew install xclogparser`
+
 ## Run tests for this plugin
 
 To run both the tests, and code style validation, run

--- a/fastlane-plugin-xclogparser.gemspec
+++ b/fastlane-plugin-xclogparser.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.author        = 'Josh Lesch'
   spec.email         = 'josh.lesch@hudl.com'
 
-  spec.summary       = 'Parse Xcode and xcodebuild build and test logs with XCLogParser'
-  # spec.homepage      = "https://github.com/<GITHUB_USERNAME>/fastlane-plugin-xclogparser"
+  spec.summary       = 'Parse Xcode or xcodebuild build and test logs with XCLogParser'
+  spec.homepage      = "https://github.com/hudl/fastlane-plugin-xclogparser"
   spec.license       = "MIT"
 
   spec.files         = Dir["lib/**/*"] + %w(README.md LICENSE)

--- a/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
+++ b/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
@@ -24,7 +24,7 @@ module Fastlane
           xclogparse_output = Action.sh(xclogparse_command)
         rescue FastlaneCore::Interface::FastlaneShellError => e
           if e.message.include?("//Logs/Build")
-            UI.error("Since Xcode 11, xcodebuild only generates the .xcactivitylog build logs when the option --resultBundlePath. If you're compiling with that command and not with Xcode, be sure to set that option to a valid path")
+            UI.error("Since Xcode 11, `xcodebuild` only generates the .xcactivitylog build logs when the option --resultBundlePath. If you're compiling with that command and not with Xcode, be sure to set that option to a valid path")
           end
           UI.user_error!(e.message)
         end
@@ -70,18 +70,18 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :command,
-                                       description: "XCLogParse command. Run `xclogparse help` to list availabel commands",
+                                       description: "XCLogParse command to execute. Run `xclogparse help` to list available commands",
                                        default_value: "parse",
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :options,
-                                       description: "Options for the XCLogParse command",
+                                       description: "Options for the XCLogParse command. Can be a string for a single option or a list of options",
                                        is_string: false,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Invalid option: #{value.inspect}, must be an Array or String") unless value.instance_of?(String) || value.instance_of?(Array)
                                        end),
           FastlaneCore::ConfigItem.new(key: :zip_html_report,
-                                       description: "Zip HTML report for transport",
+                                       description: "Zip Html if generated",
                                        is_string: false,
                                        default_value: false,
                                        optional: true)

--- a/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
+++ b/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
@@ -12,7 +12,7 @@ module Fastlane
 
         if command.eql?('parse')
           options = params[:options]
-          if options == "" || options == [] || options == nil
+          if options == "" || options == [] || options.nil?
             UI.user_error!("--reporter and oreporterne of --file, --project, --workspace, --xcodeproj parameters is required.\nSee https://github.com/spotify/XCLogParser#parse-command for more information about the Parse command.")
           end
           options = format_options(options)
@@ -33,7 +33,7 @@ module Fastlane
           report_path = parse_output_for_html_report(xclogparse_output)
           report_directory = File.dirname(report_path)
           report_time = Time.parse(File.basename(report_directory))
-          zip_name = "xclogparser_report_#{report_time.strftime("%Y-%m-%d-%H%M%S")}.zip"
+          zip_name = "xclogparser_report_#{report_time.strftime('%Y-%m-%d-%H%M%S')}.zip"
           zip_path = File.join(Dir.pwd, zip_name)
           Dir.chdir(report_directory) do
             Action.sh("zip -r -X #{zip_path} .")
@@ -77,11 +77,9 @@ module Fastlane
                                        description: "Options for the XCLogParse command",
                                        is_string: false,
                                        optional: true,
-                                       verify_block: -> (value) {
-                                        case value when String; when Array;
-                                          else  UI.user_error! "Invalid option: #{value.inspect}, must be an Array or String"
-                                        end
-                                       }),
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Invalid option: #{value.inspect}, must be an Array or String") unless value.instance_of?(String) || value.instance_of?(Array)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :zip_html_report,
                                        description: "Zip HTML report for transport",
                                        is_string: false,
@@ -91,11 +89,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        # Adjust this if your plugin only works for a particular platform (iOS vs. Android, for example)
-        # See: https://docs.fastlane.tools/advanced/#control-configuration-by-lane-and-by-platform
-        #
-        # [:ios, :mac, :android].include?(platform)
-        true
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
+++ b/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
@@ -34,10 +34,11 @@ module Fastlane
           report_directory = File.dirname(report_path)
           report_time = Time.parse(File.basename(report_directory))
           zip_name = "xclogparser_report_#{report_time.strftime("%Y-%m-%d-%H%M%S")}.zip"
-          root_dir = Dir.pwd
+          zip_path = File.join(Dir.pwd, zip_name)
           Dir.chdir(report_directory) do
-            Action.sh("zip -r -X #{File.join(root_dir, zip_name)} .")
+            Action.sh("zip -r -X #{zip_path} .")
           end
+          xclogparse_output = zip_path
         end
         xclogparse_output
       end

--- a/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
+++ b/lib/fastlane/plugin/xclogparser/actions/xclogparser_action.rb
@@ -13,7 +13,7 @@ module Fastlane
         if command.eql?('parse')
           options = params[:options]
           if options == "" || options == [] || options.nil?
-            UI.user_error!("--reporter and oreporterne of --file, --project, --workspace, --xcodeproj parameters is required.\nSee https://github.com/spotify/XCLogParser#parse-command for more information about the Parse command.")
+            UI.user_error!("--reporter and one of --file, --project, --workspace, --xcodeproj parameters is required.\nSee https://github.com/spotify/XCLogParser#parse-command for more information about the Parse command.")
           end
           options = format_options(options)
         end
@@ -30,8 +30,7 @@ module Fastlane
         end
 
         if params[:zip_html_report]
-          report_path = parse_output_for_html_report(xclogparse_output)
-          report_directory = File.dirname(report_path)
+          report_directory = File.dirname(parse_output_for_html_report(xclogparse_output))
           report_time = Time.parse(File.basename(report_directory))
           zip_name = "xclogparser_report_#{report_time.strftime('%Y-%m-%d-%H%M%S')}.zip"
           zip_path = File.join(Dir.pwd, zip_name)
@@ -52,6 +51,7 @@ module Fastlane
       end
 
       def self.parse_output_for_html_report(unparsed_output)
+        # XCLogParser outputs a formatted string to the report path.
         unparsed_output.split("Report written to ")[1]
       end
 

--- a/lib/fastlane/plugin/xclogparser/helper/xclogparser_helper.rb
+++ b/lib/fastlane/plugin/xclogparser/helper/xclogparser_helper.rb
@@ -21,13 +21,13 @@ module Fastlane
       def self.check_for_updates(installed_version)
         command = ['brew', 'outdated', 'xclogparser', '--json']
         # Brew returns a non-zero exit code if the formula is outdated
-        res = Actions.sh(command, log: false, error_callback: ->(result) {error_occurred = true})
+        res = Actions.sh(command, log: false, error_callback: ->(result) {})
         json_res = JSON.parse(res)
         return if json_res.empty?
         UI.important("\n#############################################################\n"\
                      "#  XCLogParser #{json_res[0]['current_version']} is available. You are on #{installed_version}.\n"\
                      "#  You can update using `brew upgrade xclogparser`    "\
-                     "\n############################################################")
+                     "\n#############################################################")
       end
     end
   end

--- a/spec/xclogparser_action_spec.rb
+++ b/spec/xclogparser_action_spec.rb
@@ -1,9 +1,14 @@
 describe Fastlane::Actions::XclogparserAction do
-  describe '#run' do
-    it 'prints a message' do
-      expect(Fastlane::UI).to receive(:message).with("The xclogparser plugin is working!")
-
-      Fastlane::Actions::XclogparserAction.run(nil)
+  describe 'XCLogParser Action' do
+    it 'format options' do
+      expected_array = ["--project test", "--project test"]
+      expected_string = "--project test"
+      expect(Fastlane::Actions::XclogparserAction.format_options(["--project test", "project test"])).to eq(expected_array)
+      expect(Fastlane::Actions::XclogparserAction.format_options(["project test", "--project test"])).to eq(expected_array)
+      expect(Fastlane::Actions::XclogparserAction.format_options(["project test", "project test"])).to eq(expected_array)
+      expect(Fastlane::Actions::XclogparserAction.format_options(["--project test", "--project test"])).to eq(expected_array)
+      expect(Fastlane::Actions::XclogparserAction.format_options("project test")).to eq(expected_string)
+      expect(Fastlane::Actions::XclogparserAction.format_options("--project test")).to eq(expected_string)
     end
   end
 end


### PR DESCRIPTION
This PR adds an action that will run [XCLogParser](https://github.com/spotify/XCLogParser) from your Fastfile.

The `xclogparser` action was designed to passed along the command and options to XCLogParser that should be pre-installed where Fastlane will be running, so it is recommended to read the docs that XCLogParser provides in its README.

The only added feature is to optionally zip the `html` report directory that is generated by the `parse --reporter html` command and option. This is useful with send this report to your CI server for display. 